### PR TITLE
Improvements of AnnotationUsageValidation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = 'pl.maciejkopec'
-version = '1.0.6'
+version = '1.0.7'
 sourceCompatibility = '16'
 
 repositories {

--- a/src/main/java/pl/maciejkopec/offlinemode/config/AnnotationUsageValidation.java
+++ b/src/main/java/pl/maciejkopec/offlinemode/config/AnnotationUsageValidation.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.stereotype.Component;
 import pl.maciejkopec.offlinemode.annotation.OfflineMode;
 
 import java.lang.reflect.Method;
@@ -14,7 +13,6 @@ import java.util.Map;
 import java.util.Objects;
 
 @Slf4j
-@Component
 public class AnnotationUsageValidation implements BeanPostProcessor {
 
   @Override
@@ -53,7 +51,8 @@ public class AnnotationUsageValidation implements BeanPostProcessor {
     }
 
     if (Void.class.equals(offlineMode.elementClass())
-        && Collection.class.isAssignableFrom(returnType)) {
+        && (Collection.class.isAssignableFrom(returnType)
+            || Map.class.isAssignableFrom(returnType))) {
       log.error(
           "OfflineMode is misconfigured. For Collection-like return types define elementClass. Details = {}",
           context);

--- a/src/main/java/pl/maciejkopec/offlinemode/config/OfflineModeAutoConfiguration.java
+++ b/src/main/java/pl/maciejkopec/offlinemode/config/OfflineModeAutoConfiguration.java
@@ -2,6 +2,7 @@ package pl.maciejkopec.offlinemode.config;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -30,5 +31,15 @@ public class OfflineModeAutoConfiguration {
 
     log.debug("Leaving {}", METHOD);
     return offlineModeAspect;
+  }
+
+  @Bean
+  public BeanPostProcessor annotationUsageValidationBean() {
+    final var METHOD = "annotationUsageValidationBean()";
+    log.debug("Entering {}", METHOD);
+    final var annotationUsageValidation = new AnnotationUsageValidation();
+
+    log.debug("Leaving {}", METHOD);
+    return annotationUsageValidation;
   }
 }

--- a/src/test/java/pl/maciejkopec/offlinemode/LearningModeTests.java
+++ b/src/test/java/pl/maciejkopec/offlinemode/LearningModeTests.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static java.util.function.Predicate.not;
 import static org.assertj.core.api.Assertions.assertThat;
 import static pl.maciejkopec.offlinemode.LearningModeTests.TEST_FILES_PATH;
 
@@ -35,6 +36,7 @@ class LearningModeTests {
   @AfterEach
   void tearDown() {
     Arrays.stream(Objects.requireNonNull(new File(TEST_FILES_PATH).listFiles()))
+        .filter(not(p -> p.getName().equals(".gitkeep")))
         .forEach(File::delete);
   }
 


### PR DESCRIPTION
- fix autoconfiguration of AnnotationUsageValidation
- AnnotationUsageValidation checks both key and element for Map-like types
- make sure .gitkeep is not removed